### PR TITLE
Allow custom logbook metrics

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -68,7 +68,7 @@ module.exports = (app) => {
     'navigation.courseOverGroundTrue',
     'navigation.speedThroughWater',
     'navigation.speedOverGround',
-    'navigation.attitude.roll',      // NEW: heel/roll in radians
+    'navigation.attitude.roll', // NEW: heel/roll in radians
     'navigation.log',
     'navigation.courseRhumbline.nextPoint.position',
     'environment.outside.pressure',

--- a/plugin/triggers.js
+++ b/plugin/triggers.js
@@ -3,11 +3,11 @@ const stateToEntry = require('./format');
 
 // convert m/s to knots
 function toKnots(mps) {
-  return mps * 1.943844;  // 1 m/s ≈ 1.9438 kt
+  return mps * 1.943844; // 1 m/s ≈ 1.9438 kt
 }
 // convert radians to degrees
 function radToDeg(rad) {
-  return rad * 180 / Math.PI;
+  return (rad * 180) / Math.PI;
 }
 
 function isUnderWay(state) {
@@ -112,7 +112,7 @@ exports.processTriggers = function processTriggers(path, value, oldState, log, a
         }
       }
       break;
-    }    
+    }
     case 'steering.autopilot.state': {
       if (oldState[path] === value || !oldState[path]) {
         // We can ignore state when it doesn't change
@@ -145,8 +145,8 @@ exports.processTriggers = function processTriggers(path, value, oldState, log, a
         return appendLog('Anchored', {
           end: true,
           'custom.logbook.maxSpeed': 0,
-          'custom.logbook.maxWind':  0,
-          'custom.logbook.maxHeel':  0
+          'custom.logbook.maxWind': 0,
+          'custom.logbook.maxHeel': 0,
         });
       }
       if (value === 'sailing') {
@@ -177,8 +177,8 @@ exports.processTriggers = function processTriggers(path, value, oldState, log, a
         return appendLog('Stopped', {
           end: true,
           'custom.logbook.maxSpeed': 0,
-          'custom.logbook.maxWind':  0,
-          'custom.logbook.maxHeel':  0
+          'custom.logbook.maxWind': 0,
+          'custom.logbook.maxHeel': 0,
         });
       }
       break;

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -171,6 +171,8 @@ components:
     Entry:
       type: object
       additionalProperties: false
+      patternProperties:
+        "^custom\\.logbook\\.": {}
       required:
       - datetime
       - text


### PR DESCRIPTION
## Summary
- permit `custom.logbook.*` fields in log entry schema so automatic metrics like `custom.logbook.maxSpeed` can be saved
- tidy plugin sources for linting, including clearer conversion utilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b1ee70fe08331838b6c93ef18932b