### PR TITLE
Allow custom logbook fields for speed and wind records

### DIFF
--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -281,6 +281,12 @@ components:
           type: array
           items:
             type: string
+        'custom.logbook.maxSpeed':
+          type: number
+        'custom.logbook.maxWind':
+          type: number
+        'custom.logbook.maxHeel':
+          type: number
         end:
           type: boolean
           default: false


### PR DESCRIPTION
## Summary
- allow `custom.logbook.maxSpeed` and `custom.logbook.maxWind` fields
- also document `custom.logbook.maxHeel`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689be5b611948331bb4693002b73aa9d