### PR TITLE
Allow custom logbook metrics

### DIFF
--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -156,6 +156,8 @@ components:
     NewEntry:
       type: object
       additionalProperties: false
+      patternProperties:
+        "^custom\\.logbook\\.": {}
       required:
       - text
       properties:
@@ -168,6 +170,12 @@ components:
           maximum: 15
         observations:
           $ref: '#/components/schemas/Observations'
+        'custom.logbook.maxSpeed':
+          type: number
+        'custom.logbook.maxWind':
+          type: number
+        'custom.logbook.maxHeel':
+          type: number
     Entry:
       type: object
       additionalProperties: false


### PR DESCRIPTION
## Summary
- permit custom.logbook.* fields in NewEntry schema
- document maxSpeed, maxWind and maxHeel custom metrics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bee541ce88331807582cc15324e9b