### PR TITLE
Log cumulative course over ground changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This application provides both a server-side plugin and the user interface for m
 
 * Entries written when starting/ending a trip (requires [signalk-autostate](https://github.com/meri-imperiumi/signalk-autostate) plugin)
 * When underway, an entry is created every hour recording the current conditions
+* Automatic entry when course over ground changes by more than 25°
 
 ## User interface
 


### PR DESCRIPTION
## Summary
- Track the last recorded course and log an entry when the course over ground deviates by 25° or more
- Reset stored course when anchoring or mooring
- Document automatic course-change logging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c3ab8153c83319dd935bd362df9ff